### PR TITLE
Use switch-hal to simplify active high/low output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ repository = "https://github.com/david-sawatzke/embedded-morse"
 
 [dependencies]
 embedded-hal = "0.2.3"
+switch-hal = "0.3.2"


### PR DESCRIPTION
I don't know if you actually want to merge this.
The switch-hal API isn't very stable at the moment.
I just thought it was neat and you might like to see it.